### PR TITLE
11 add icon circle component

### DIFF
--- a/resources/css/components/icon-circle.css
+++ b/resources/css/components/icon-circle.css
@@ -1,0 +1,31 @@
+@layer components {
+  .icon-circle,
+  .icon-circle-lg,
+  .icon-circle-xl {
+    @apply bg-gold text-rhoendorf flex items-center justify-center rounded-full;
+  }
+
+  .icon-circle {
+    @apply size-10;
+
+    svg {
+      @apply size-6;
+    }
+  }
+
+  .icon-circle-lg {
+    @apply size-16;
+
+    svg {
+      @apply size-10;
+    }
+  }
+
+  .icon-circle-xl {
+    @apply size-28;
+
+    svg {
+      @apply size-20;
+    }
+  }
+}

--- a/resources/css/components/icon-circle.css
+++ b/resources/css/components/icon-circle.css
@@ -1,7 +1,8 @@
 @layer components {
   .icon-circle,
   .icon-circle-lg,
-  .icon-circle-xl {
+  .icon-circle-xl,
+  .icon-circle-2xl {
     @apply bg-gold text-rhoendorf flex items-center justify-center rounded-full;
   }
 
@@ -26,6 +27,14 @@
 
     svg {
       @apply size-20;
+    }
+  }
+
+  .icon-circle-2xl {
+    @apply size-36;
+
+    svg {
+      @apply size-26;
     }
   }
 }

--- a/resources/demo.css
+++ b/resources/demo.css
@@ -99,7 +99,7 @@
 
   #icon-circle {
     ul {
-      @apply mt-4 grid max-w-screen-md grid-cols-3 items-center gap-4;
+      @apply mt-4 grid max-w-screen-md grid-cols-4 items-center gap-4;
 
       li > figure {
         @apply flex h-full w-full flex-col items-center justify-end;

--- a/resources/demo.css
+++ b/resources/demo.css
@@ -97,6 +97,20 @@
     }
   }
 
+  #icon-circle {
+    ul {
+      @apply mt-4 grid max-w-screen-md grid-cols-3 items-center gap-4;
+
+      li > figure {
+        @apply flex h-full w-full flex-col items-center justify-end;
+
+        figcaption {
+          @apply mt-2 text-sm;
+        }
+      }
+    }
+  }
+
   #arc {
     ul {
       @apply mt-4 grid grid-cols-3 gap-4;

--- a/resources/index.css
+++ b/resources/index.css
@@ -2,6 +2,7 @@
 @import "./css/typography.css";
 
 @import "./css/components/button.css";
+@import "./css/components/icon-circle.css";
 @import "./css/components/union-title.css";
 
 @import "./css/utilities/arc.css";

--- a/resources/index.html
+++ b/resources/index.html
@@ -225,35 +225,52 @@
             <span>Leben die Blindtexte</span>
           </h4>
         </section>
-        <section>
+        <section id="icon-circle">
           <h3>Icon Circle</h3>
-          <figure class="icon-circle">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
-              />
-            </svg>
-          </figure>
-          <figure class="icon-circle-lg">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
-              />
-            </svg>
-          </figure>
-          <figure class="icon-circle-xl">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
-              />
-            </svg>
-          </figure>
+          <ul>
+            <li>
+              <figure>
+                <figure class="icon-circle">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
+                    />
+                  </svg>
+                </figure>
+                <figcaption>Default</figcaption>
+              </figure>
+            </li>
+            <li>
+              <figure>
+                <figure class="icon-circle-lg">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
+                    />
+                  </svg>
+                </figure>
+                <figcaption>Large</figcaption>
+              </figure>
+            </li>
+            <li>
+              <figure>
+                <figure class="icon-circle-xl">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
+                    />
+                  </svg>
+                </figure>
+                <figcaption>XL</figcaption>
+              </figure>
+            </li>
+          </ul>
         </section>
       </section>
       <section id="utilities">

--- a/resources/index.html
+++ b/resources/index.html
@@ -253,7 +253,7 @@
                     />
                   </svg>
                 </figure>
-                <figcaption>Large</figcaption>
+                <figcaption>LG</figcaption>
               </figure>
             </li>
             <li>
@@ -268,6 +268,20 @@
                   </svg>
                 </figure>
                 <figcaption>XL</figcaption>
+              </figure>
+            </li>
+            <li>
+              <figure>
+                <figure class="icon-circle-2xl">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
+                    />
+                  </svg>
+                </figure>
+                <figcaption>2XL</figcaption>
               </figure>
             </li>
           </ul>

--- a/resources/index.html
+++ b/resources/index.html
@@ -225,6 +225,36 @@
             <span>Leben die Blindtexte</span>
           </h4>
         </section>
+        <section>
+          <h3>Icon Circle</h3>
+          <figure class="icon-circle">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
+              />
+            </svg>
+          </figure>
+          <figure class="icon-circle-lg">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
+              />
+            </svg>
+          </figure>
+          <figure class="icon-circle-xl">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0M3.124 7.5A8.969 8.969 0 0 1 5.292 3m13.416 0a8.969 8.969 0 0 1 2.168 4.5"
+              />
+            </svg>
+          </figure>
+        </section>
       </section>
       <section id="utilities">
         <h2>Utilities</h2>


### PR DESCRIPTION
 **PR Summary by Typo**
------------

**Overview**
This PR introduces a new `icon-circle` component with four size variants (default, lg, xl, 2xl).  The component is a circular container designed to hold an icon, with styling applied for background color, text color, and layout.  Demo HTML has been added to showcase the component.

**Key Changes**
- Added `icon-circle.css` file containing the styles for the new component.
- Imported `icon-circle.css` into `index.css`.
- Added a demo section to `index.html` and `demo.css` to showcase the `icon-circle` component in different sizes.

**Recommendations**
Ready to merge after visual review of the rendered `icon-circle` component in the demo to ensure proper sizing and styling across different size variants.
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>