### PR TITLE
✨ Enhance Call to Action component for dark mode support

### DIFF
--- a/resources/css/components/cta.css
+++ b/resources/css/components/cta.css
@@ -3,10 +3,14 @@
     @apply mx-auto;
 
     &:not(.with-image) {
-      @apply bg-rhoendorf relative flex flex-col items-center justify-center px-6 py-16 text-center text-white;
+      @apply bg-rhoendorf dark:bg-rhoendorf-60 relative flex flex-col items-center justify-center overflow-hidden px-6 py-16 text-center text-white;
 
       .overlay {
         @apply absolute top-0 left-0 z-0;
+      }
+
+      .body {
+        @apply z-1;
       }
 
       .title,


### PR DESCRIPTION
This pull request introduces a small enhancement to the `resources/css/components/cta.css` file. The change improves the styling of call-to-action (CTA) components by adding support for a dark mode background and ensuring proper layering of elements.

* Added a `dark:bg-rhoendorf-60` class to support dark mode styling for the CTA component.
* Introduced a `.body` class with `z-1` to ensure it is layered above the `.overlay`.
 
 **PR Summary by Typo**
------------

**Overview:** This PR adds dark mode support to the Call to Action (CTA) component by modifying the background color and adding a z-index to ensure content visibility.

**Key Changes:**
- Updated the CTA component's styling to include a dark mode background color.
- Added a `z-index` to the body content within the CTA to prevent overlap issues in dark mode.

**Recommendations:**
Ready for deployment. This simple change effectively addresses dark mode compatibility for the CTA component.

### 🗂️ Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 4 (80.0%)      |
| Rework      | 1 (20.0%)      |
| Total Changes | 5            |
 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>