### PR TITLE
🔧 Add :astro preset to Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>derteaser/renovate-presets", ":preserveSemverRanges", "schedule:weekends"]
+  "extends": [
+    "github>derteaser/renovate-presets",
+    "github>derteaser/renovate-presets:astro",
+    ":preserveSemverRanges",
+    "schedule:weekends"
+  ]
 }


### PR DESCRIPTION
## Summary

Adds the `:astro` preset from [derteaser/renovate-presets](https://github.com/derteaser/renovate-presets) on top of the existing universal baseline.

## Why

The preset repo now ships ecosystem-specific named presets. `:astro` currently groups `@astro-community/*` plugins (core `astro` + `@astrojs/*` are already covered by Renovate's built-in `monorepo:astro`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the Renovate configuration to include a preset specifically for Astro projects.

#### Key Changes
- Added `github>derteaser/renovate-presets:astro` to the `extends` array in `renovate.json`, enabling Renovate to manage Astro-related dependencies.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 5 (83.3%)     |
| Rework      | 1 (16.7%)     |
| Total Changes | 6             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>