### PR TITLE
Add Renovate preset for downstream consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ For PHP projects that don't need `node_modules` in production, install via Compo
 
 > **Note:** The CSS, JS, and fonts are still provided via the NPM package (or your build pipeline / CDN). The Composer package only delivers the PHP template components and auto-registration.
 
+### Renovate
+
+If your project uses [Renovate](https://docs.renovatebot.com/) to keep dependencies up to date, extend this repo's preset so Renovate knows where to look up the package — it is published to GitHub Packages (npm) and a VCS repository (composer), not to npmjs.org or Packagist:
+
+```json
+{
+  "extends": ["github>CDU-Neuss/cdu-brand:renovate-preset"]
+}
+```
+
+The preset configures the correct registry URLs for both the npm and composer packages. Authentication for GitHub Packages still needs to be configured in your own Renovate `hostRules` or environment — if Renovate reports auth errors after extending the preset, that is the next thing to check.
+
 ## Usage
 
 ### Import the Theme

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate preset for repos consuming @cdu-neuss/cdu-brand. Tells Renovate the package is published to GitHub Packages (npm) and a VCS repository (composer), not to npmjs.org or Packagist.",
+  "packageRules": [
+    {
+      "description": "Resolve @cdu-neuss/cdu-brand from GitHub Packages npm registry",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@cdu-neuss/cdu-brand"],
+      "registryUrls": ["https://npm.pkg.github.com"]
+    },
+    {
+      "description": "Resolve cdu-neuss/cdu-brand from the GitHub VCS repository (no Packagist entry)",
+      "matchManagers": ["composer"],
+      "matchPackageNames": ["cdu-neuss/cdu-brand"],
+      "registryUrls": ["https://github.com/CDU-Neuss/cdu-brand"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `renovate-preset.json` at the repo root: a shareable Renovate preset that overrides `registryUrls` for both the npm and composer ecosystems so Renovate knows the package is distributed via GitHub Packages / VCS and not Packagist or npmjs.org.
- Documents the preset in [README.md](README.md) under the existing Composer section, with a one-line `extends` snippet and an `hostRules` auth pointer.

## Why

Consumer repos using Renovate currently see this on their dependency dashboards:

> Failed to look up packagist package cdu-neuss/cdu-brand: no-result.

The composer package is installed via a VCS `repositories` entry (no Packagist publication), and the npm package lives on GitHub Packages. Without explicit `registryUrls`, Renovate's default Packagist/npmjs.org lookup fails. The preset moves that boilerplate from every consumer's `renovate.json` into one canonical place here.

## Why not `default.json`

This repo already has its own [renovate.json](renovate.json) (extending `derteaser/renovate-presets` and `schedule:weekends` for *this* repo's deps). Renovate's preset resolution order for `github>org/repo` is `default.json` → `renovate.json` → `renovate.json5`. Using a `default.json` means a future deletion or rename silently exposes this repo's internal config to consumers. The explicit `renovate-preset.json` filename forces consumers to use `:renovate-preset` and sidesteps that fallback chain — and it's self-documenting in a brand-asset repo where a generic `default.json` would be opaque.

## Consumer usage

```json
{
  "extends": ["github>CDU-Neuss/cdu-brand:renovate-preset"]
}
```

## Test plan

- [x] `jq . renovate-preset.json` — valid JSON
- [x] `npx renovate-config-validator renovate-preset.json` — `Config validated successfully`
- [ ] After merge: extend the preset from a consumer repo, trigger a Renovate run, confirm the *Failed to look up packagist package cdu-neuss/cdu-brand* warning disappears from the dependency dashboard
- [ ] Confirm Renovate proposes a PR (or reports up-to-date) for both `cdu-neuss/cdu-brand` (composer) and `@cdu-neuss/cdu-brand` (npm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)