### PR TITLE
Switch composer side of Renovate preset to github-tags datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ If your project uses [Renovate](https://docs.renovatebot.com/) to keep dependenc
 }
 ```
 
-The preset configures the correct registry URLs for both the npm and composer packages. Authentication for GitHub Packages still needs to be configured in your own Renovate `hostRules` or environment — if Renovate reports auth errors after extending the preset, that is the next thing to check.
+For composer the preset disables the default Packagist lookup (which fails with `no-result` because the package is not on Packagist) and replaces it with a `customManagers` regex that reads the pinned version straight from your `composer.json` and resolves updates via the `github-tags` datasource — no changes to your `composer.json` `repositories` block are needed.
+
+For npm the preset points lookups at `https://npm.pkg.github.com`. Authentication for GitHub Packages still needs to be configured in your own Renovate `hostRules` or environment — if Renovate reports auth errors for the npm package after extending the preset, that is the next thing to check.
 
 ## Usage
 

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "description": "Renovate preset for repos consuming @cdu-neuss/cdu-brand. Tells Renovate the package is published to GitHub Packages (npm) and a VCS repository (composer), not to npmjs.org or Packagist.",
+  "description": "Renovate preset for repos consuming @cdu-neuss/cdu-brand. Tells Renovate the package is published to GitHub Packages (npm) and a GitHub VCS repository (composer), not to npmjs.org or Packagist.",
   "packageRules": [
     {
       "description": "Resolve @cdu-neuss/cdu-brand from GitHub Packages npm registry",
@@ -9,10 +9,20 @@
       "registryUrls": ["https://npm.pkg.github.com"]
     },
     {
-      "description": "Resolve cdu-neuss/cdu-brand from the GitHub VCS repository (no Packagist entry)",
-      "matchManagers": ["composer"],
+      "description": "Disable the default composer/Packagist lookup for cdu-neuss/cdu-brand — handled by the customManagers entry below, which reads versions directly from GitHub tags",
       "matchPackageNames": ["cdu-neuss/cdu-brand"],
-      "registryUrls": ["https://github.com/CDU-Neuss/cdu-brand"]
+      "matchDatasources": ["packagist"],
+      "enabled": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/(^|/)composer\\.json$/"],
+      "matchStrings": ["\"cdu-neuss/cdu-brand\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "cdu-neuss/cdu-brand",
+      "packageNameTemplate": "CDU-Neuss/cdu-brand",
+      "datasourceTemplate": "github-tags"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Real-world test in [CDU-RKN/cdu-im-rhein-kreis-neuss-processwire](https://github.com/CDU-RKN/cdu-im-rhein-kreis-neuss-processwire/issues/226) showed the original preset (#210) didn't actually clear the dependency-dashboard warning:

> Failed to look up packagist package cdu-neuss/cdu-brand: no-result.

Root cause: overriding `registryUrls` for the composer manager doesn't help, because Renovate's **packagist datasource** only understands HTTP `packages.json` endpoints — handing it a raw GitHub repo URL still fails. The composer half of the preset was a no-op.

## Fix

Adopt the pattern used by [`derteaser/renovate-presets:kirby`](https://github.com/derteaser/renovate-presets/blob/main/kirby.json) for the analogous `derteaser/kirby-testing` VCS-only Composer package:

1. **Disable** the packagist datasource for `cdu-neuss/cdu-brand` via a `packageRule` that matches the package name and the packagist datasource.
2. **Replace** it with a `customManagers` regex that reads the pinned version directly out of `composer.json` and resolves updates through the `github-tags` datasource pointed at `CDU-Neuss/cdu-brand`.

The npm `packageRule` is unchanged — that side already works.

Tags on this repo are bare semver (`1.14.1`, not `v1.14.1`), so no `extractVersionTemplate` is needed (the kirby reference strips a `v` prefix).

## Consumer impact

Consumers don't need to change their `composer.json` (no `name` hint required on the `repositories` entry — the customManager bypasses Renovate's composer manager entirely for this package). The one-line `extends` in their `renovate.json` keeps working as documented.

## Test plan

- [x] `jq . renovate-preset.json` — valid JSON
- [x] `npx renovate-config-validator renovate-preset.json` — `Config validated successfully`
- [ ] After merge: trigger Renovate in [CDU-RKN/cdu-im-rhein-kreis-neuss-processwire](https://github.com/CDU-RKN/cdu-im-rhein-kreis-neuss-processwire), confirm the *Failed to look up packagist package cdu-neuss/cdu-brand* warning is gone from the dependency dashboard
- [ ] Confirm Renovate proposes a PR upgrading `cdu-neuss/cdu-brand` from `1.13.1` to `1.14.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the Renovate preset to improve how it handles the `cdu-neuss/cdu-brand` composer package. It switches the composer side of the Renovate preset to use the `github-tags` datasource, resolving issues with failed Packagist lookups.

#### Key Changes
- Disabled the default Packagist lookup for `cdu-neuss/cdu-brand` in `renovate-preset.json`.
- Added a `customManagers` entry to `renovate-preset.json` to use a regex to extract the version from `composer.json` and resolve updates via `github-tags`.
- Updated the description in `renovate-preset.json` and `README.md` to reflect the new composer package update strategy.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 13 (72.2%)    |
| Churn       | 1 (5.6%)      |
| Rework      | 4 (22.2%)     |
| Total Changes | 18          | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>