### PR TITLE
Add dark-mode variants for button and union-title

### DIFF
--- a/docs/src/pages/button.astro
+++ b/docs/src/pages/button.astro
@@ -54,20 +54,16 @@ import ButtonComponent from "../../../resources/astro/components/Button.astro";
     </p>
     <ul>
       <li>
-        <ButtonComponent color="blue" class="dark:btn-blue-inverted">btn-blue dark:btn-blue-inverted</ButtonComponent>
+        <ButtonComponent color="blue" class="dark:btn-blue-inverted">Blue → Inverted</ButtonComponent>
       </li>
       <li>
-        <ButtonComponent color="gold" class="dark:btn-gold-inverted">btn-gold dark:btn-gold-inverted</ButtonComponent>
+        <ButtonComponent color="gold" class="dark:btn-gold-inverted">Gold → Inverted</ButtonComponent>
       </li>
       <li>
-        <ButtonComponent color="blue-transparent" class="dark:btn-blue-inverted"
-          >btn-blue-transparent dark:btn-blue-inverted</ButtonComponent
-        >
+        <ButtonComponent color="blue-transparent" class="dark:btn-blue-inverted">Blue Transparent → Inverted</ButtonComponent>
       </li>
       <li>
-        <ButtonComponent color="gold-transparent" class="dark:btn-gold-inverted"
-          >btn-gold-transparent dark:btn-gold-inverted</ButtonComponent
-        >
+        <ButtonComponent color="gold-transparent" class="dark:btn-gold-inverted">Gold Transparent → Inverted</ButtonComponent>
       </li>
     </ul>
   </section>

--- a/docs/src/pages/button.astro
+++ b/docs/src/pages/button.astro
@@ -46,6 +46,31 @@ import ButtonComponent from "../../../resources/astro/components/Button.astro";
       </li>
     </ul>
   </section>
+
+  <section id="buttons-dark" class="dark bg-rhoendorf mt-12 rounded p-6">
+    <h2 class="mb-4 text-white">Dark-mode variants</h2>
+    <p class="mb-4 text-white">
+      Pair an unprefixed color with a <code>dark:</code>-prefixed one. The dark variant only applies inside a <code>.dark</code> ancestor.
+    </p>
+    <ul>
+      <li>
+        <ButtonComponent color="blue" class="dark:btn-blue-inverted">btn-blue dark:btn-blue-inverted</ButtonComponent>
+      </li>
+      <li>
+        <ButtonComponent color="gold" class="dark:btn-gold-inverted">btn-gold dark:btn-gold-inverted</ButtonComponent>
+      </li>
+      <li>
+        <ButtonComponent color="blue-transparent" class="dark:btn-blue-inverted"
+          >btn-blue-transparent dark:btn-blue-inverted</ButtonComponent
+        >
+      </li>
+      <li>
+        <ButtonComponent color="gold-transparent" class="dark:btn-gold-inverted"
+          >btn-gold-transparent dark:btn-gold-inverted</ButtonComponent
+        >
+      </li>
+    </ul>
+  </section>
 </Layout>
 
 <style>
@@ -57,6 +82,16 @@ import ButtonComponent from "../../../resources/astro/components/Button.astro";
 
       li {
         @apply border-rhoendorf-10 flex flex-col items-center border p-4;
+      }
+    }
+  }
+
+  #buttons-dark {
+    ul {
+      @apply mt-4 grid max-w-screen-md grid-cols-1 gap-4 sm:grid-cols-2;
+
+      li {
+        @apply border-rhoendorf-60 bg-rhoendorf flex flex-col items-center border p-4;
       }
     }
   }

--- a/resources/css/components/button.css
+++ b/resources/css/components/button.css
@@ -11,87 +11,87 @@
     --btn-border-color-disabled: var(--color-rhoendorf-10);
     --btn-text-color-disabled: var(--color-rhoendorf-60);
   }
+}
 
-  .btn-gold {
-    --btn-background-color: var(--color-gold);
-    --btn-background-color-hover: var(--color-gold-110);
-    --btn-border-color: var(--color-gold);
-    --btn-border-color-hover: var(--color-gold-110);
-    --btn-text-color: var(--color-rhoendorf);
-    --btn-text-color-hover: var(--color-rhoendorf);
-  }
+@utility btn-gold {
+  --btn-background-color: var(--color-gold);
+  --btn-background-color-hover: var(--color-gold-110);
+  --btn-border-color: var(--color-gold);
+  --btn-border-color-hover: var(--color-gold-110);
+  --btn-text-color: var(--color-rhoendorf);
+  --btn-text-color-hover: var(--color-rhoendorf);
+}
 
-  .btn-gold-inverted {
-    --btn-background-color: var(--color-white);
-    --btn-background-color-hover: var(--color-gold-110);
-    --btn-border-color: var(--color-white);
-    --btn-border-color-hover: var(--color-gold-110);
-    --btn-text-color: var(--color-gold-110);
-    --btn-text-color-hover: var(--color-white);
-  }
+@utility btn-gold-inverted {
+  --btn-background-color: var(--color-white);
+  --btn-background-color-hover: var(--color-gold-110);
+  --btn-border-color: var(--color-white);
+  --btn-border-color-hover: var(--color-gold-110);
+  --btn-text-color: var(--color-gold-110);
+  --btn-text-color-hover: var(--color-white);
+}
 
-  .btn-gold-transparent {
-    --btn-background-color: var(--color-transparent);
-    --btn-background-color-hover: var(--color-gold);
-    --btn-border-color: var(--color-gold);
-    --btn-border-color-hover: var(--color-gold);
-    --btn-text-color: var(--color-gold-110);
-    --btn-text-color-hover: var(--color-white);
-  }
+@utility btn-gold-transparent {
+  --btn-background-color: var(--color-transparent);
+  --btn-background-color-hover: var(--color-gold);
+  --btn-border-color: var(--color-gold);
+  --btn-border-color-hover: var(--color-gold);
+  --btn-text-color: var(--color-gold-110);
+  --btn-text-color-hover: var(--color-white);
+}
 
-  .btn-blue {
-    --btn-background-color: var(--color-rhoendorf);
-    --btn-background-color-hover: var(--color-rhoendorf-60);
-    --btn-border-color: var(--color-rhoendorf);
-    --btn-border-color-hover: var(--color-rhoendorf-60);
-    --btn-text-color: var(--color-white);
-    --btn-text-color-hover: var(--color-white);
-  }
+@utility btn-blue {
+  --btn-background-color: var(--color-rhoendorf);
+  --btn-background-color-hover: var(--color-rhoendorf-60);
+  --btn-border-color: var(--color-rhoendorf);
+  --btn-border-color-hover: var(--color-rhoendorf-60);
+  --btn-text-color: var(--color-white);
+  --btn-text-color-hover: var(--color-white);
+}
 
-  .btn-blue-inverted {
-    --btn-background-color: var(--color-white);
-    --btn-background-color-hover: var(--color-rhoendorf-60);
-    --btn-border-color: var(--color-white);
-    --btn-border-color-hover: var(--color-rhoendorf-60);
-    --btn-text-color: var(--color-rhoendorf);
-    --btn-text-color-hover: var(--color-white);
-  }
+@utility btn-blue-inverted {
+  --btn-background-color: var(--color-white);
+  --btn-background-color-hover: var(--color-rhoendorf-60);
+  --btn-border-color: var(--color-white);
+  --btn-border-color-hover: var(--color-rhoendorf-60);
+  --btn-text-color: var(--color-rhoendorf);
+  --btn-text-color-hover: var(--color-white);
+}
 
-  .btn-blue-transparent {
-    --btn-background-color: var(--color-transparent);
-    --btn-background-color-hover: var(--color-rhoendorf);
-    --btn-border-color: var(--color-rhoendorf);
-    --btn-border-color-hover: var(--color-rhoendorf);
-    --btn-text-color: var(--color-rhoendorf);
-    --btn-text-color-hover: var(--color-white);
-  }
+@utility btn-blue-transparent {
+  --btn-background-color: var(--color-transparent);
+  --btn-background-color-hover: var(--color-rhoendorf);
+  --btn-border-color: var(--color-rhoendorf);
+  --btn-border-color-hover: var(--color-rhoendorf);
+  --btn-text-color: var(--color-rhoendorf);
+  --btn-text-color-hover: var(--color-white);
+}
 
-  .btn-link {
-    --btn-background-color: var(--color-transparent);
-    --btn-background-color-hover: var(--color-transparent);
-    --btn-border-color: var(--color-transparent);
-    --btn-border-color-hover: var(--color-transparent);
-    --btn-text-color: var(--color-rhoendorf);
-    --btn-text-color-hover: var(--color-rhoendorf);
-  }
+@utility btn-link {
+  --btn-background-color: var(--color-transparent);
+  --btn-background-color-hover: var(--color-transparent);
+  --btn-border-color: var(--color-transparent);
+  --btn-border-color-hover: var(--color-transparent);
+  --btn-text-color: var(--color-rhoendorf);
+  --btn-text-color-hover: var(--color-rhoendorf);
+}
 
-  .btn-facebook {
-    --btn-background-color: var(--color-facebook);
-    --btn-background-color-hover: var(--color-white);
-    --btn-border-color: var(--color-facebook);
-    --btn-border-color-hover: var(--color-facebook);
-    --btn-text-color: var(--color-white);
-    --btn-text-color-hover: var(--color-facebook);
-  }
+@utility btn-facebook {
+  --btn-background-color: var(--color-facebook);
+  --btn-background-color-hover: var(--color-white);
+  --btn-border-color: var(--color-facebook);
+  --btn-border-color-hover: var(--color-facebook);
+  --btn-text-color: var(--color-white);
+  --btn-text-color-hover: var(--color-facebook);
+}
 
-  .btn-whatsapp {
-    --btn-background-color: var(--color-whatsapp);
-    --btn-background-color-hover: var(--color-white);
-    --btn-border-color: var(--color-whatsapp);
-    --btn-border-color-hover: var(--color-whatsapp);
-    --btn-text-color: var(--color-white);
-    --btn-text-color-hover: var(--color-whatsapp);
-  }
+@utility btn-whatsapp {
+  --btn-background-color: var(--color-whatsapp);
+  --btn-background-color-hover: var(--color-white);
+  --btn-border-color: var(--color-whatsapp);
+  --btn-border-color-hover: var(--color-whatsapp);
+  --btn-text-color: var(--color-white);
+  --btn-text-color-hover: var(--color-whatsapp);
 }
 
 @layer components {

--- a/resources/css/components/union-title.css
+++ b/resources/css/components/union-title.css
@@ -25,6 +25,30 @@
   }
 }
 
+@utility union-title-on-cadenabbia {
+  --union-title-background-color: var(--color-cadenabbia);
+  --union-title-text-color: var(--color-rhoendorf);
+  --union-title-text-strong-color: var(--color-gold);
+}
+
+@utility union-title-on-gold {
+  --union-title-background-color: var(--color-gold);
+  --union-title-text-color: var(--color-rhoendorf);
+  --union-title-text-strong-color: var(--color-white);
+}
+
+@utility union-title-on-rhoendorf {
+  --union-title-background-color: var(--color-rhoendorf);
+  --union-title-text-color: var(--color-white);
+  --union-title-text-strong-color: var(--color-gold);
+}
+
+@utility union-title-on-white {
+  --union-title-background-color: var(--color-white);
+  --union-title-text-color: var(--color-rhoendorf);
+  --union-title-text-strong-color: var(--color-gold);
+}
+
 @layer components {
   .union-title {
     @apply overflow-hidden bg-transparent! break-words;


### PR DESCRIPTION
## Summary

- Convert button color modifiers in `resources/css/components/button.css` from `@layer base { .btn-* }` selectors to Tailwind v4 `@utility` declarations. This unlocks variant prefixes (`dark:`, `hover:`, responsive, etc.) on every button color, so consumers can pair light/dark variants explicitly: `<button class="btn btn-blue dark:btn-blue-inverted">`.
- Add new `union-title-on-{cadenabbia,gold,rhoendorf,white}` `@utility` modifiers in `resources/css/components/union-title.css` alongside the existing `.bg-*`-triggered defaults, providing a dark-mode escape hatch without breaking the auto-theming pattern.
- Add a "Dark-mode variants" demo section to `docs/src/pages/button.astro` showing four typical pairings inside a `.dark` wrapper.

## Why

The brand package already wires up the `dark` variant in `docs/src/styles/global.css` via `@custom-variant dark (&:is(.dark *))`, but the button color modifiers were declared as plain CSS class selectors inside `@layer base`. Tailwind v4 only composes variants onto utilities it knows about (via `@utility`, etc.), so `dark:btn-blue-inverted` previously generated no rules. Converting the modifiers to `@utility` blocks is a minimal change that unlocks the full variant system across the existing palette — no new color variants needed.

## Notes for reviewers

- **No template-engine changes**: Blade, Twig, Antlers, and Astro button components already merge consumer-supplied classes (via `$attributes`, `class` parameter, `{{ class }}`, and `class:list` respectively), so the new `dark:*` utilities work end-to-end without touching those wrappers.
- **Backward compat**: The `:root` defaults block in `button.css`, the `.btn` / `.close-btn` components, and the existing `.bg-*`-triggered union-title defaults are all preserved. Consumers using the old API continue to work unchanged.
- **No new dependencies**, no theme.css changes, no test changes (`tests/package-structure.test.js` only verifies file structure, which is unchanged).
- Class-order behavior: `class="btn btn-blue dark:btn-blue-inverted"` resolves correctly because Tailwind orders `dark:` variants after unprefixed utilities in the generated stylesheet, so the inverted custom properties win inside `.dark`.

## Test plan

- [x] `pnpm -C docs dev` and open `/cdu-brand/button` — confirm the existing button grid renders identically.
- [x] In the new "Dark-mode variants" section, verify each `btn-* dark:btn-*-inverted` button switches palette correctly (the section is wrapped in a `.dark` ancestor).
- [x] In DevTools, inspect a `btn-blue dark:btn-blue-inverted` element inside `.dark`: `--btn-background-color` should resolve to `var(--color-white)`. Outside `.dark`, it should resolve to `var(--color-rhoendorf)`.
- [x] `pnpm run lint` clean at repo root.
- [x] `cd docs && pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR introduces dark-mode variants for buttons and union-titles, enhancing the UI's adaptability to different themes. It also refactors existing button styles into utility directives for better maintainability.

#### Key Changes
- Added a new section to `button.astro` demonstrating dark-mode button variants (e.g., `dark:btn-blue-inverted`).
- Converted all existing button styles in `button.css` from class-based definitions to `@utility` directives.
- Introduced new `@utility` directives for `union-title` components in `union-title.css` to support various background color contexts.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 56 (43.8%) lines |
| Churn       | 1 (0.8%) lines |
| Rework      | 71 (55.5%) lines |
| Total Changes | 128 (100.0%) lines | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>